### PR TITLE
大佬，发现您的项目引入了com.thoughtworks.xstream:xstream@1.4.15组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>top.codewood.wx</groupId>
@@ -53,7 +51,7 @@
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.15</version>
+            <version>1.4.19</version>
         </dependency>
         <dependency>
             <groupId>org.dom4j</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：XStream 代码问题漏洞
缺陷组件：com.thoughtworks.xstream:xstream@1.4.15
漏洞编号：CVE-2021-39139
漏洞描述：XStream是XStream（Xstream）团队的一个轻量级的、简单易用的开源Java类库，它主要用于将对象序列化成XML（JSON）或反序列化为对象。
XStream 1.4.17及之前版本存在代码问题漏洞，远程攻击者可以通过操纵处理后的输入流，从远程主机加载和执行任意代码。
影响范围：(∞, 1.4.18)
最小修复版本：1.4.19
缺陷组件引入路径：top.codewood.wx:wx-java-common@1.0.6->com.thoughtworks.xstream:xstream@1.4.15
```
另外我运行这个项目时，IDE的安全插件提示还有159个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p33f75